### PR TITLE
Configure Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,2 @@
+docker_builder:
+  make_script: ./makefiles/docker_make.sh

--- a/makefiles/docker_make.sh
+++ b/makefiles/docker_make.sh
@@ -7,4 +7,4 @@ set -e
 docker ps > /dev/null
 
 # do the real exec
-docker run --privileged -v $(pwd):/root/axiom-firmware/ -w /root/axiom-firmware/ -it jatha/axiom-build-container:latest /bin/bash -c "make -f makefiles/host/main.mk -I makefiles/host -j -l $(nproc) $*"
+docker run --privileged -v $(pwd):/root/axiom-firmware/ -w /root/axiom-firmware/ jatha/axiom-build-container:latest /bin/bash -c "make -f makefiles/host/main.mk -I makefiles/host -j -l $(nproc) $*"


### PR DESCRIPTION
Use [Docker Builder](https://cirrus-ci.org/guide/docker-builder/) to run CI scripts.

Here is a link to corresponding Cirrus CI task on my fork: https://cirrus-ci.com/task/6603040834453504

@anuejn PTAL